### PR TITLE
feat(error): add codeframe for displaying syntax and semantic errors

### DIFF
--- a/compiler/compiler/Compiler.re
+++ b/compiler/compiler/Compiler.re
@@ -77,7 +77,7 @@ let add =
     raise(CircularDependencyDetected);
   };
 
-  let loaded = ref(Loader.load(Parser.prog, absolute_path));
+  let loaded = ref(Loader.load(Parser.prog, absolute_path, relative_path));
 
   Log.info(
     "%s  %s (%s)",
@@ -151,7 +151,7 @@ let inject =
     ) => {
   Log.info("%s  %s (%s)", Emoji.syringe, pretty_path, name);
 
-  let loaded = Loader.load(Parser.defn, absolute_path);
+  let loaded = Loader.load(Parser.defn, absolute_path, relative_path);
 
   Log.info(
     "%s  %s (%s)",

--- a/compiler/compiler/Loader.re
+++ b/compiler/compiler/Loader.re
@@ -6,39 +6,43 @@ module Parser = KnotParse.Parser;
 
 let buffer_size = 1000;
 
-let load = (prog, file) => {
-  let in_channel = Util.cache_as_tmp(buffer_size, file);
+let load = (prog, file, pretty_path) => {
+  let tmp_file = Util.cache_as_tmp(buffer_size, file);
+  let in_channel = open_in(tmp_file);
 
-  try (
-    UnicodeFileStream.of_channel(in_channel)
-    |> TokenStream.of_file_stream(~filter=TokenStream.filter_comments)
-    |> Parser.parse(prog)
-    |> (
-      fun
-      | Some(_) as res => {
-          close_in(in_channel);
-          res;
-        }
-      | None => raise(ParsingFailed)
-    )
-  ) {
-  | err =>
-    Printf.sprintf("failed to parse file '%s'", file) |> print_endline;
-
-    switch (err) {
-    | InvalidCharacter(ch, cursor) =>
-      Printf.sprintf(
-        "encountered unexpected character '%s' at [%d, %d]",
-        print_uchar(ch),
-        fst(cursor),
-        snd(cursor),
+  let result =
+    try (
+      UnicodeFileStream.of_channel(in_channel)
+      |> TokenStream.of_file_stream(~filter=TokenStream.filter_comments)
+      |> Parser.parse(prog)
+      |> (
+        fun
+        | Some(_) as res => res
+        | None => raise(ParsingFailed)
       )
-      |> print_endline
-    | _ =>
-      /* unexpected exception was caught */
-      ()
+    ) {
+    | err =>
+      switch (err) {
+      | InvalidCharacter(ch, cursor) =>
+        print_err(
+          pretty_path,
+          Printf.sprintf(
+            "encountered unexpected character '%s' at [%d, %d]",
+            print_uchar(ch),
+            fst(cursor),
+            snd(cursor),
+          ),
+        );
+        Knot.CodeFrame.print(tmp_file, cursor) |> print_endline;
+      | _ =>
+        /* unexpected exception was caught */
+        ()
+      };
+
+      raise(LexingFailed);
     };
 
-    raise(LexingFailed);
-  };
+  close_in(in_channel);
+
+  result;
 };

--- a/compiler/compiler/Util.re
+++ b/compiler/compiler/Util.re
@@ -38,7 +38,7 @@ let cache_as_tmp = (buffer_size, file) =>
       close_out(tmp_channel);
       close_in(in_channel);
 
-      open_in(tmp_file);
+      tmp_file;
     }
   );
 

--- a/compiler/library/CodeFrame.re
+++ b/compiler/library/CodeFrame.re
@@ -1,0 +1,75 @@
+let frame_padding_size = 4;
+
+let add_line_number = (buf, row, margin_size) => {
+  let line_number = string_of_int(row);
+  Printf.sprintf(
+    "%s%s",
+    ANSITerminal.(sprintf([blue], "%s", line_number)),
+    String.make(margin_size - String.length(line_number), ' '),
+  )
+  |> Buffer.add_string(buf);
+};
+
+let print = (file, cursor) => {
+  let in_channel = open_in(file);
+  let read_char = UnicodeFileReader.of_channel(in_channel);
+  let start_row = max(1, fst(cursor) - frame_padding_size);
+  let end_row = fst(cursor) + 1;
+  let margin_size = (string_of_int(end_row) |> String.length) + 1;
+
+  if (start_row != 1) {
+    let rec skip = () =>
+      switch (read_char()) {
+      | Newline((curr_row, _)) when curr_row == start_row => ()
+      | _ => skip()
+      };
+    skip();
+  };
+
+  let buf = Buffer.create(512);
+  Buffer.add_char(buf, '\n');
+  add_line_number(buf, start_row, margin_size);
+
+  let indicator_added = ref(false);
+  let add_indicator = () => {
+    indicator_added := true;
+
+    ANSITerminal.(
+      Printf.sprintf(
+        "%s%s\n",
+        String.make(snd(cursor) - 1 + margin_size, ' '),
+        sprintf([red, Bold], "^"),
+      )
+    )
+    |> Buffer.add_string(buf);
+  };
+
+  let rec loop = () =>
+    switch (read_char()) {
+    | Newline((row, _)) when row == fst(cursor) + frame_padding_size + 1 =>
+      ()
+    | Newline(ch_cursor) =>
+      Buffer.add_char(buf, '\n');
+
+      if (! indicator_added^ && fst(ch_cursor) == fst(cursor) + 1) {
+        add_indicator();
+      };
+
+      add_line_number(buf, fst(ch_cursor), margin_size);
+
+      loop();
+    | Character(ch, (row, col)) =>
+      Buffer.add_utf_8_uchar(buf, ch);
+      loop();
+    | EndOfFile =>
+      if (! indicator_added^) {
+        add_indicator();
+      }
+    };
+  loop();
+
+  close_in(in_channel);
+  Buffer.add_char(buf, '\n');
+
+  Buffer.contents(buf);
+};

--- a/compiler/library/Debug_Token.re
+++ b/compiler/library/Debug_Token.re
@@ -71,6 +71,5 @@ let print_tkn =
     | String(s) => Printf.sprintf("string(%s)", s)
     | LineComment(s) => Printf.sprintf("line_comment(%s)", s)
     | BlockComment(s) => Printf.sprintf("block_comment(%s)", s)
-    | Unexpected(c) => Printf.sprintf("UNEXPECTED(%c)", c)
   )
   % String.escaped;

--- a/compiler/library/Exception.re
+++ b/compiler/library/Exception.re
@@ -2,3 +2,14 @@ exception NotImplemented;
 exception InvalidDotAccess;
 exception UnanalyzedTypeReference;
 exception InvalidCharacter(Uchar.t, (int, int));
+
+let print_err = (file, error) =>
+  ANSITerminal.(
+    sprintf(
+      [red],
+      "[ERROR]: failed to parse file '%s'\n\n%s",
+      file,
+      String.capitalize_ascii(error),
+    )
+  )
+  |> print_endline;

--- a/compiler/library/Token.re
+++ b/compiler/library/Token.re
@@ -62,5 +62,4 @@ type token =
   | Boolean(bool)
   | JSXTextNode(string)
   | LineComment(string)
-  | BlockComment(string)
-  | Unexpected(char);
+  | BlockComment(string);

--- a/compiler/library/UnicodeFileReader.re
+++ b/compiler/library/UnicodeFileReader.re
@@ -1,0 +1,35 @@
+open Globals;
+
+type t =
+  | Newline((int, int))
+  | Character(Uchar.t, (int, int))
+  | EndOfFile;
+
+let normalized_newline_char_code = 10;
+
+let of_channel = channel => {
+  let decoder =
+    Uutf.decoder(
+      ~nln=`Readline(Uchar.of_int(normalized_newline_char_code)),
+      `Channel(channel),
+    );
+
+  let get_cursor = () => (
+    Uutf.decoder_line(decoder),
+    Uutf.decoder_col(decoder),
+  );
+
+  () =>
+    switch (Uutf.decode(decoder)) {
+    | `Uchar(uch) =>
+      let cursor = get_cursor();
+      switch (Uchar.to_int(uch)) {
+      | x when x == normalized_newline_char_code => Newline(cursor)
+      | _ => Character(uch, cursor)
+      };
+    | `End => EndOfFile
+    | `Malformed(_) => Character(Uutf.u_rep, get_cursor())
+    /* this will not happen unless providing a manual source */
+    | `Await => assert(false)
+    };
+};

--- a/compiler/library/UnicodeFileStream.re
+++ b/compiler/library/UnicodeFileStream.re
@@ -1,40 +1,10 @@
 open Globals;
 
-type t =
-  | Newline((int, int))
-  | Character(Uchar.t, (int, int))
-  | EndOfFile;
-
-let normalized_newline_char_code = 10;
-
 let of_channel = channel => {
-  let decoder =
-    Uutf.decoder(
-      ~nln=`Readline(Uchar.of_int(normalized_newline_char_code)),
-      `Channel(channel),
-    );
-
-  let get_cursor = () => (
-    Uutf.decoder_line(decoder),
-    Uutf.decoder_col(decoder),
-  );
-
-  let next = () =>
-    switch (Uutf.decode(decoder)) {
-    | `Uchar(uch) =>
-      let cursor = get_cursor();
-      switch (Uchar.to_int(uch)) {
-      | x when x == normalized_newline_char_code => Newline(cursor)
-      | _ => Character(uch, cursor)
-      };
-    | `End => EndOfFile
-    | `Malformed(_) => Character(Uutf.u_rep, get_cursor())
-    /* this will not happen unless providing a manual source */
-    | `Await => assert(false)
-    };
+  let read_char = UnicodeFileReader.of_channel(channel);
 
   LazyStream.of_function(() =>
-    switch (next()) {
+    switch (read_char()) {
     /* found a newline */
     | Newline(cursor) => Some((Uchar.of_char('\n'), cursor))
     /* found a character */

--- a/compiler/library/dune
+++ b/compiler/library/dune
@@ -7,5 +7,5 @@
    (name Knot)
    ; Other libraries list this name in their package.json 'require' field to use this library.
    (public_name knot.lib)
-   (libraries  opal dolog emoji uutf )
+   (libraries  opal dolog emoji uutf ANSITerminal )
 )

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -18,7 +18,8 @@
         "opal",
         "dolog",
         "emoji",
-        "uutf"
+        "uutf",
+        "ANSITerminal"
       ],
       "name": "knot.lib",
       "namespace": "Knot"

--- a/compiler/test/TestSuite.re
+++ b/compiler/test/TestSuite.re
@@ -12,8 +12,8 @@ let () = {
 
         ANSITerminal.(
           Printf.sprintf("\n[%s] suite failed!\n", sprintf([red], "x"))
-          |> print_endline
-        );
+        )
+        |> print_endline;
 
         exit(-1);
       },
@@ -30,9 +30,7 @@ let () = {
 
   failed^ ?
     () :
-    ANSITerminal.(
-      sprintf([green], "✓")
-      |> Printf.sprintf("\n[%s] Test suite successful!")
-      |> print_endline
-    );
+    ANSITerminal.(sprintf([green], "✓"))
+    |> Printf.sprintf("\n[%s] Test suite successful!")
+    |> print_endline;
 };


### PR DESCRIPTION
affects: @knot/compiler