### PR TITLE
feat(comments): change comment syntax

### DIFF
--- a/compiler/executable/Error.re
+++ b/compiler/executable/Error.re
@@ -23,7 +23,7 @@ let _print_syntax_error = (file, print) =>
 
   | UnclosedCommentBlock(cursor) => {
       Printf.sprintf(
-        "no closing tag (///) found for comment block starting at [%d:%d]",
+        "no closing tag (*/) found for comment block starting at [%d:%d]",
         fst(cursor),
         snd(cursor),
       )

--- a/compiler/lexer/Comment.re
+++ b/compiler/lexer/Comment.re
@@ -2,7 +2,8 @@ open Core;
 open Match;
 open Matcher;
 
-let _triple_slash = "///";
+let _comment_start = "/*";
+let _comment_end = "*/";
 
 let _prefixed_line_matcher = t =>
   Matcher(
@@ -12,7 +13,7 @@ let _prefixed_line_matcher = t =>
         LookaheadMatcher(forward_slash, [end_of_line], t),
         LookaheadMatcher(
           forward_slash,
-          [Not(Any([forward_slash, end_of_line]))],
+          [Not(end_of_line)],
           Util.match_until_eol(t),
         ),
       ]
@@ -21,12 +22,13 @@ let _prefixed_line_matcher = t =>
 
 let matchers = [
   Util.match_bounded(
-    _triple_slash,
+    _comment_start,
+    _comment_end,
     cursor => UnclosedCommentBlock(cursor),
     get_string => {
       let string = get_string();
 
-      BlockComment(String.sub(string, 3, String.length(string) - 6))
+      BlockComment(String.sub(string, 2, String.length(string) - 4))
       |> result;
     },
   ),

--- a/compiler/lexer/Identifier.re
+++ b/compiler/lexer/Identifier.re
@@ -5,7 +5,8 @@ open Matcher;
 let _first_char = Any([underscore, alpha]);
 let _subsequent_char = Any([underscore, alphanumeric]);
 
-let _match_subsequent_chars = Util.match_while(_subsequent_char);
+let _match_subsequent_chars = (t, _) =>
+  Util.match_while(_subsequent_char, t) |> many;
 
 let _single_char_identifier_matcher =
   LookaheadMatcher(

--- a/compiler/lexer/Number.re
+++ b/compiler/lexer/Number.re
@@ -2,11 +2,7 @@ open Core;
 open Match;
 open Matcher;
 
-let rec matchers = [
-  LookaheadMatcher(
-    numeric,
-    [Not(numeric)],
-    get_string => Number(int_of_string(get_string())) |> result,
-  ),
-  LookaheadMatcher(numeric, [numeric], _ => many(matchers)),
-];
+let matchers =
+  Util.match_while(numeric, get_string =>
+    Number(int_of_string(get_string())) |> result
+  );

--- a/compiler/lexer/Text.re
+++ b/compiler/lexer/Text.re
@@ -5,14 +5,16 @@ open Matcher;
 let matchers = [
   Matcher(
     quote,
-    Util.match_until_char(
-      quote,
-      cursor => UnclosedString(cursor),
-      get_string => {
-        let string = get_string();
+    _ =>
+      Util.match_until_char(
+        quote,
+        cursor => UnclosedString(cursor),
+        get_string => {
+          let string = get_string();
 
-        String(String.sub(string, 1, String.length(string) - 2)) |> result;
-      },
-    ),
+          String(String.sub(string, 1, String.length(string) - 2)) |> result;
+        },
+      )
+      |> many,
   ),
 ];

--- a/compiler/test/LexerTest.re
+++ b/compiler/test/LexerTest.re
@@ -62,7 +62,7 @@ let tests =
         switch (
           Lexer.next_token(
             to_file_stream(
-              "/// this is an unclosed comment block \nwith new \nlines in it",
+              "/* this is an unclosed comment block \nwith new \nlines in it",
             ),
           )
         ) {
@@ -161,9 +161,9 @@ let tests =
           ("//\n", LineComment("")),
           ("//", LineComment("")),
           (
-            "///931lkj das\n e1;lk312///",
+            "/*931lkj das\n e1;lk312*/",
             BlockComment("931lkj das\n e1;lk312"),
           ),
-          ("//////", BlockComment("")),
+          ("/**/", BlockComment("")),
         ]),
   ];

--- a/compiler/test/resources/project/src/index.kn
+++ b/compiler/test/resources/project/src/index.kn
@@ -3,6 +3,10 @@ import * as Utils from ".utils"
 
 const ABC = <div>{greet("World")}</div>;
 
+/*
+this is a comment
+*/
+
 view SimpleView -> (
   <div>
     {ABC}

--- a/compiler/test/resources/snippets/sample.kn
+++ b/compiler/test/resources/snippets/sample.kn
@@ -2,9 +2,9 @@
 
 // this comment should be ignored
 
-///
+/*
 this multi-line comment should also be ignored
-///
+*/
 
 const numericConst = 8;
 const additionConst = 1 + 10;
@@ -73,19 +73,19 @@ func paramFunc(a: number) -> a;
 // view TypedParamView (a: boolean) -> { }
 // view DefaultParamView (a = 4) -> { }
 // view MultiParamView (m: boolean, a: number = 2) -> { }
-///
+/*
 view InheritingView : SuperView -> {
   a + b;
   8;
 }
-///
+*/
 // view MixinView () ~ MyMixin -> {}
 // view InheritingMixinView () : SuperView ~ MyMixin -> {}
-///
+/*
 view ComplexView () : SuperView ~ MyMixin, OtherMixin -> {
   e + f;
 }
-///
+*/
 
 // style ClassStyle {
 //   .root {

--- a/compiler/test/resources/unix_module.txt
+++ b/compiler/test/resources/unix_module.txt
@@ -2,9 +2,9 @@ import ABC from "abc";
 
 // this comment should be ignored
 
-///
+/*
 this multi-line comment should also be ignored
-///
+*/
 
 const numericConst = 8;
 const additionConst = 1 + 10;

--- a/compiler/test/resources/unix_tokens.txt
+++ b/compiler/test/resources/unix_tokens.txt
@@ -1,9 +1,9 @@
 +/+-* &/{ 9(3<2= =  90-   >
 "BC" [-+*>/]>= 300=$
 5 412)|) }// dth asd elkjqw
-</"123123" ==///
+</"123123" ==/*
 .a41#@
-///~||&&<==/>
+*/~||&&<==/>
 
 / >| |< / &  &
 main import const let state view func if else get mut

--- a/compiler/test/resources/windows_tokens.txt
+++ b/compiler/test/resources/windows_tokens.txt
@@ -1,9 +1,9 @@
 +/+-* &/{ 9(3<2= =  90-   >
 "BC" [-+*>/]>= 300=$
 5 412)|) }// dth asd elkjqw
-</"123123" ==///
+</"123123" ==/*
 .a41#@
-///~||&&<==/>
+*/~||&&<==/>
 
 / >| |< / &  &
 main import const let state view func if else get mut

--- a/extensions/syntax.iro
+++ b/extensions/syntax.iro
@@ -1,9 +1,9 @@
 #################################################################
 ## Iro
-################################################################ 
+################################################################
 ##
 ## * Press Ctrl + '+'/'-' To Zoom in
-## * Press Ctrl + S to save and recalculate... 
+## * Press Ctrl + S to save and recalculate...
 ## * Documents are saved to web storage.
 ## * Only one save slot supported.
 ## * Matches cannot span lines.
@@ -166,13 +166,13 @@ main : context {
       regex     \= $${__KEYWORDS}
       styles [] = .keyword;
    }
-   
+
    : include "entity" ;
-   
+
    : include "closure" ;
-   
+
    : include "catch_all" ;
-   
+
 }
 
 ###########################################
@@ -184,25 +184,25 @@ closure : context {
       uid = uid_braces_closure
       regex         \= (\{)
       styles []     = .punctuation;
-      
-      : pop {  
+
+      : pop {
          regex      \= (\})
          styles []  = .punctuation;
       }
-      
+
       : include "main" ;
    }
-   
+
    : inline_push {
       uid = uid_parentheses_closure
       regex         \= (\()
       styles []     = .punctuation;
-      
+
       : pop {
          regex      \= (\))
          styles []  = .punctuation;
       }
-      
+
       : include "closure_list" ;
    }
 }
@@ -210,7 +210,7 @@ closure : context {
 closure_list : context {
    : include "closure" ;
    : include "catch_all" ;
-   
+
    : pattern {
       regex      \= (,)
       styles []  = .punctuation;
@@ -226,7 +226,7 @@ catch_all : context {
    : include "comment" ;
    : include "operator" ;
    : include "punctuation" ;
-   
+
    : pattern {
       regex     \= ([^\s])
       styles [] = .illegal;
@@ -300,7 +300,7 @@ string : context {
       regex         \= (\")
       styles []     = .text;
       default_style = .text
-      
+
       : pop {
          regex      \= (\")
          styles []  = .text;
@@ -327,12 +327,12 @@ function_call : context {
    : inline_push {
       regex     \= ($${__IDENTIFIER})(\s*)(\()
       styles [] = .function, .whitespace, .punctuation;
-      
+
       : pop {
          regex \= (\))
          styles [] = .punctuation;
       }
-      
+
       : include "closure_list" ;
    }
 }
@@ -357,7 +357,7 @@ identifier : context {
       regex     \= (\B\$$${__IDENTIFIER})
       styles [] = .injected;
    }
-   
+
    : pattern {
       regex     \= (\b$${__IDENTIFIER})
       styles [] = .identifier;
@@ -379,29 +379,29 @@ jsx : context {
       uid = uid_self_closing_jsx
       regex     \= (<)(\s*)($${__IDENTIFIER})
       styles [] = .punctuation, .whitespace, .jsx_tag;
-      
+
       : pop {
          regex \= (/>|>)
          styles [] = .punctuation;
       }
-      
+
       : pattern {
          regex \= (\b$${__IDENTIFIER})(\s*)(=)(\s*)(\"[^"]*\")
          styles [] = .jsx_property, .whitespace, .punctuation, .whitespace, .text;
       }
-      
+
       : inline_push {
          regex \= (\b$${__IDENTIFIER})(\s*)(=)(\s*)({)
          styles [] = .jsx_property, .whitespace, .punctuation, .whitespace, .punctuation;
-         
+
          : pop {
             regex \= (})
             styles [] = .punctuation;
          }
-         
+
          : include "main";
       }
-      
+
       : pattern {
          regex \= (\b$${__IDENTIFIER})
          styles [] = .jsx_property;
@@ -416,12 +416,12 @@ jsx : context {
 comment : context {
    : inline_push {
       uid = uid_block_comment
-      regex         \= (///)
+      regex         \= (/*)
       styles []     = .comment;
       default_style = .comment
-      
+
       : pop {
-         regex      \= (///)
+         regex      \= (*/)
          styles []  = .comment;
       }
    }

--- a/extensions/vscode/language-configuration.json
+++ b/extensions/vscode/language-configuration.json
@@ -2,19 +2,11 @@
   // symbols used for comments
   "comments": {
     "lineComment": "//",
-    "blockComment": [
-      "///",
-      "///"
-    ]
+    "blockComment": ["/*", "*/"]
   },
 
   // symbols used as brackets
-  "brackets": [
-    ["{", "}"],
-    ["[", "]"],
-    ["(", ")"],
-    ["<", ">"]
-  ],
+  "brackets": [["{", "}"], ["[", "]"], ["(", ")"], ["<", ">"]],
 
   // symbols that are auto-closed when typing
   "autoClosingPairs": [
@@ -25,7 +17,7 @@
     ["\"", "\""],
     ["'", "'"],
     ["`", "`"],
-    ["///", "///"]
+    ["/*", "*/"]
   ],
 
   // symbols that can be used to surround a selection

--- a/extensions/vscode/syntaxes/knot.tmLanguage
+++ b/extensions/vscode/syntaxes/knot.tmLanguage
@@ -4,14 +4,14 @@
 <!-- Generated via Iro -->
 <dict>
   <key>fileTypes</key>
-  <array> 
+  <array>
     <string>kn</string>
     <string>knot</string>
    </array>
   <key>name</key>
   <string>knot</string>
   <key>patterns</key>
-  <array> 
+  <array>
     <dict>
       <key>include</key>
       <string>#main</string>
@@ -26,7 +26,7 @@
     <key>main</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#keyword</string>
@@ -48,7 +48,7 @@
     <key>boolean</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(true|false)</string>
@@ -60,7 +60,7 @@
     <key>catch_all</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#expression</string>
@@ -88,7 +88,7 @@
     <key>closure</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>begin</key>
           <string>(\{)</string>
@@ -101,7 +101,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#uid_braces_closure</string>
@@ -130,7 +130,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#uid_parentheses_closure</string>
@@ -159,7 +159,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#uid_brackets_closure</string>
@@ -181,7 +181,7 @@
     <key>closure_list</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#closure</string>
@@ -201,10 +201,10 @@
     <key>comment</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>begin</key>
-          <string>(///)</string>
+          <string>(/*)</string>
           <key>beginCaptures</key>
           <dict>
             <key>1</key>
@@ -216,7 +216,7 @@
           <key>contentName</key>
           <string>comment.knot</string>
           <key>end</key>
-          <string>(///)</string>
+          <string>(*/)</string>
           <key>endCaptures</key>
           <dict>
             <key>1</key>
@@ -237,7 +237,7 @@
     <key>entity</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#state</string>
@@ -269,7 +269,7 @@
     <key>expression</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#string</string>
@@ -303,7 +303,7 @@
     <key>function_call</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>begin</key>
           <string>(\w[\w]*)(\s*)(\()</string>
@@ -326,7 +326,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#function_call__1</string>
@@ -348,7 +348,7 @@
     <key>function_call__1</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#closure_list</string>
@@ -358,7 +358,7 @@
     <key>identifier</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(\B\$\w[\w]*)</string>
@@ -376,7 +376,7 @@
     <key>jsx</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(&lt;/)(\s*)(\w[\w]*)(\s*)(&gt;)</string>
@@ -431,7 +431,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#uid_self_closing_jsx</string>
@@ -453,7 +453,7 @@
     <key>jsx__2</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#main</string>
@@ -463,7 +463,7 @@
     <key>keyword</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(import|from|main|as)</string>
@@ -475,7 +475,7 @@
     <key>numeric</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(\B-\d+)|(\b\d+)</string>
@@ -487,7 +487,7 @@
     <key>operator</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(-&gt;|==|!=|\|\||&amp;&amp;|[\x{003d}.\x{002b}\-\x{002a}\x{002f}\x{007e}\x{0021}])</string>
@@ -499,7 +499,7 @@
     <key>punctuation</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(&lt;/|/&gt;|[\x{003a}\x{003b}\x{002c}\x{003c}\x{003e}])</string>
@@ -511,7 +511,7 @@
     <key>state</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>begin</key>
           <string>\b(state)(\s*)(\w[\w]*)(\s*)({)</string>
@@ -544,7 +544,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#state__1</string>
@@ -566,7 +566,7 @@
     <key>state__1</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#state_property</string>
@@ -580,7 +580,7 @@
     <key>state_property</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>\b(mut|get)(\s*)(\w[\w]*)</string>
@@ -625,7 +625,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#state_property__1</string>
@@ -654,7 +654,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#state_property__2</string>
@@ -682,7 +682,7 @@
     <key>state_property__1</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#main</string>
@@ -692,7 +692,7 @@
     <key>state_property__2</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#main</string>
@@ -702,7 +702,7 @@
     <key>string</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>begin</key>
           <string>(\&quot;)</string>
@@ -732,13 +732,13 @@
     <key>string__1</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
        </array>
     </dict>
     <key>type_definition</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(:)(\s*)(\w[\w]*)</string>
@@ -766,13 +766,13 @@
     <key>uid_block_comment</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
        </array>
     </dict>
     <key>uid_braces_closure</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#main</string>
@@ -782,7 +782,7 @@
     <key>uid_brackets_closure</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#closure_list</string>
@@ -792,7 +792,7 @@
     <key>uid_parentheses_closure</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>include</key>
           <string>#closure_list</string>
@@ -802,7 +802,7 @@
     <key>uid_self_closing_jsx</key>
     <dict>
       <key>patterns</key>
-      <array> 
+      <array>
         <dict>
           <key>match</key>
           <string>(\b\w[\w]*)(\s*)(=)(\s*)(\&quot;[^\x{0022}]*\&quot;)</string>
@@ -867,7 +867,7 @@
             </dict>
           </dict>
           <key>patterns</key>
-          <array> 
+          <array>
             <dict>
               <key>include</key>
               <string>#jsx__2</string>


### PR DESCRIPTION
affects: @knot/compiler

use `/*` and `*/` as the open and close tags for block comments

a friend of mine pointed out that comment blocks have symmetrical
tags for good reason, to avoid causing ambiguity between the end of one comment block and the beginning of another when a file contains many block comments